### PR TITLE
replace context.TODO()s

### DIFF
--- a/network/p2p/p2p.go
+++ b/network/p2p/p2p.go
@@ -53,7 +53,7 @@ const AlgorandWsProtocol = "/algorand-ws/1.0.0"
 const dialTimeout = 30 * time.Second
 
 // MakeService creates a P2P service instance
-func MakeService(log logging.Logger, cfg config.Local, datadir string, pstore peerstore.Peerstore, wsStreamHandler StreamHandler) (*Service, error) {
+func MakeService(ctx context.Context, log logging.Logger, cfg config.Local, datadir string, pstore peerstore.Peerstore, wsStreamHandler StreamHandler) (*Service, error) {
 	// load stored peer ID, or make ephemeral peer ID
 	privKey, err := GetPrivKey(cfg, datadir)
 	if err != nil {
@@ -84,8 +84,7 @@ func MakeService(log logging.Logger, cfg config.Local, datadir string, pstore pe
 	h.Network().Notify(sm)
 	h.SetStreamHandler(AlgorandWsProtocol, sm.streamHandler)
 
-	psCtx := context.TODO()
-	ps, err := makePubSub(psCtx, cfg, h)
+	ps, err := makePubSub(ctx, cfg, h)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +94,7 @@ func MakeService(log logging.Logger, cfg config.Local, datadir string, pstore pe
 		host:      h,
 		streams:   sm,
 		pubsub:    ps,
-		pubsubCtx: psCtx,
+		pubsubCtx: ctx,
 		topics:    make(map[string]*pubsub.Topic),
 	}, nil
 }

--- a/network/p2p/streams.go
+++ b/network/p2p/streams.go
@@ -71,7 +71,7 @@ func (n *streamManager) streamHandler(stream network.Stream) {
 				n.log.Infof("Failed to check old stream with %s: %v", remotePeer, err)
 			}
 			n.streams[stream.Conn().RemotePeer()] = stream
-			n.handler(context.TODO(), remotePeer, stream, true)
+			n.handler(context.Background(), remotePeer, stream, true)
 			return
 		}
 		// otherwise, the old stream is still open, so we can close the new one
@@ -80,7 +80,7 @@ func (n *streamManager) streamHandler(stream network.Stream) {
 	}
 	// no old stream
 	n.streams[stream.Conn().RemotePeer()] = stream
-	n.handler(context.TODO(), remotePeer, stream, true)
+	n.handler(context.Background(), remotePeer, stream, true)
 }
 
 // Connected is called when a connection is opened
@@ -107,7 +107,7 @@ func (n *streamManager) Connected(net network.Network, conn network.Conn) {
 	}
 
 	n.streams[remotePeer] = stream
-	n.handler(context.TODO(), remotePeer, stream, false)
+	n.handler(context.Background(), remotePeer, stream, false)
 }
 
 // Disconnected is called when a connection is closed

--- a/network/p2p/streams.go
+++ b/network/p2p/streams.go
@@ -30,6 +30,7 @@ import (
 
 // streamManager implements network.Notifiee to create and manage streams for use with non-gossipsub protocols.
 type streamManager struct {
+	ctx     context.Context
 	log     logging.Logger
 	host    host.Host
 	handler StreamHandler
@@ -41,8 +42,9 @@ type streamManager struct {
 // StreamHandler is called when a new bidirectional stream for a given protocol and peer is opened.
 type StreamHandler func(ctx context.Context, pid peer.ID, s network.Stream, incoming bool)
 
-func makeStreamManager(log logging.Logger, h host.Host, handler StreamHandler) *streamManager {
+func makeStreamManager(ctx context.Context, log logging.Logger, h host.Host, handler StreamHandler) *streamManager {
 	return &streamManager{
+		ctx:     ctx,
 		log:     log,
 		host:    h,
 		handler: handler,
@@ -71,7 +73,7 @@ func (n *streamManager) streamHandler(stream network.Stream) {
 				n.log.Infof("Failed to check old stream with %s: %v", remotePeer, err)
 			}
 			n.streams[stream.Conn().RemotePeer()] = stream
-			n.handler(context.Background(), remotePeer, stream, true)
+			n.handler(n.ctx, remotePeer, stream, true)
 			return
 		}
 		// otherwise, the old stream is still open, so we can close the new one
@@ -80,7 +82,7 @@ func (n *streamManager) streamHandler(stream network.Stream) {
 	}
 	// no old stream
 	n.streams[stream.Conn().RemotePeer()] = stream
-	n.handler(context.Background(), remotePeer, stream, true)
+	n.handler(n.ctx, remotePeer, stream, true)
 }
 
 // Connected is called when a connection is opened
@@ -100,14 +102,14 @@ func (n *streamManager) Connected(net network.Network, conn network.Conn) {
 		return // there's already an active stream with this peer for our protocol
 	}
 
-	stream, err := n.host.NewStream(context.Background(), remotePeer, AlgorandWsProtocol)
+	stream, err := n.host.NewStream(n.ctx, remotePeer, AlgorandWsProtocol)
 	if err != nil {
 		n.log.Infof("Failed to open stream to %s: %v", remotePeer, err)
 		return
 	}
 
 	n.streams[remotePeer] = stream
-	n.handler(context.Background(), remotePeer, stream, false)
+	n.handler(n.ctx, remotePeer, stream, false)
 }
 
 // Disconnected is called when a connection is closed

--- a/network/p2pNetwork.go
+++ b/network/p2pNetwork.go
@@ -132,7 +132,7 @@ func NewP2PNetwork(log logging.Logger, cfg config.Local, datadir string, phonebo
 		broadcastQueueBulk:     make(chan broadcastRequest, 100),
 	}
 
-	net.service, err = p2p.MakeService(log, cfg, datadir, pstore, net.wsStreamHandler)
+	net.service, err = p2p.MakeService(net.ctx, log, cfg, datadir, pstore, net.wsStreamHandler)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (n *P2PNetwork) Address() (string, bool) {
 func (n *P2PNetwork) Broadcast(ctx context.Context, tag protocol.Tag, data []byte, wait bool, except Peer) error {
 	// For tags using pubsub topics, publish to GossipSub
 	if topic, ok := n.topicTags[tag]; ok {
-		return n.service.Publish(context.TODO(), topic, data)
+		return n.service.Publish(ctx, topic, data)
 	}
 	// Otherwise broadcast over websocket protocol stream
 	return n.broadcaster.BroadcastArray(ctx, []protocol.Tag{tag}, [][]byte{data}, wait, except)
@@ -343,7 +343,7 @@ func (n *P2PNetwork) wsStreamHandler(ctx context.Context, peer peer.ID, stream n
 	}
 	// create a wsPeer for this stream and added it to the peers map.
 	wsp := &wsPeer{
-		wsPeerCore: makePeerCore(context.TODO(), n, n.log, n.handler.readBuffer, addr, n.GetRoundTripper(), addr),
+		wsPeerCore: makePeerCore(ctx, n, n.log, n.handler.readBuffer, addr, n.GetRoundTripper(), addr),
 		conn:       &wsPeerConnP2PImpl{stream: stream},
 	}
 	wsp.init(n.config, outgoingMessagesBufferSize)

--- a/network/p2pNetwork_test.go
+++ b/network/p2pNetwork_test.go
@@ -88,7 +88,7 @@ func TestP2PSubmitTX(t *testing.T) {
 
 	// send messages from B and confirm that they get received by C (via A)
 	for i := 0; i < 10; i++ {
-		err = netB.Broadcast(context.TODO(), protocol.TxnTag, []byte(fmt.Sprintf("hello %d", i)), false, nil)
+		err = netB.Broadcast(context.Background(), protocol.TxnTag, []byte(fmt.Sprintf("hello %d", i)), false, nil)
 		require.NoError(t, err)
 	}
 
@@ -168,7 +168,7 @@ func TestP2PSubmitWS(t *testing.T) {
 
 	// send messages from B and confirm that they get received by C (via A)
 	for i := 0; i < 10; i++ {
-		err = netB.Broadcast(context.TODO(), testTag, []byte(fmt.Sprintf("hello %d", i)), false, nil)
+		err = netB.Broadcast(context.Background(), testTag, []byte(fmt.Sprintf("hello %d", i)), false, nil)
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
Replaces all context.TODO()s with threading through the main cancellable p2p network context with the exception of tests where we use context.Background() instead. 