### PR TITLE
Put all `*Block` interfaces into `bookkeeping` with `Block`

### DIFF
--- a/agreement/abstractions.go
+++ b/agreement/abstractions.go
@@ -78,28 +78,7 @@ type BlockFactory interface {
 	// produce an UnfinishedBlock for the given round. If an insufficient number of
 	// nodes on the network can assemble entries, the agreement protocol may
 	// lose liveness.
-	AssembleBlock(rnd basics.Round, partAddresses []basics.Address) (UnfinishedBlock, error)
-}
-
-// An UnfinishedBlock represents a Block produced by a BlockFactory
-// and must be finalized before being proposed by agreement.
-type UnfinishedBlock interface {
-	// WithSeed creates a copy of this UnfinishedBlock with its
-	// cryptographically random seed set to the given value.
-	//
-	// Calls to Seed() or to Digest() on the copy's Block must
-	// reflect the value of the new seed.
-	FinishBlock(seed committee.Seed, proposer basics.Address, eligible bool) ProposableBlock
-
-	Round() basics.Round
-}
-
-// An ProposableBlock represents a Block produced by a BlockFactory,
-// that was later finalized by providing the seed and the proposer,
-// and can now be proposed by agreement.
-type ProposableBlock interface {
-	// Block returns the underlying block that has been assembled.
-	Block() bookkeeping.Block
+	AssembleBlock(rnd basics.Round, partAddresses []basics.Address) (bookkeeping.UnfinishedBlock, error)
 }
 
 // A Ledger represents the sequence of Entries agreed upon by the protocol.

--- a/agreement/agreementtest/simulate_test.go
+++ b/agreement/agreementtest/simulate_test.go
@@ -83,7 +83,7 @@ func (b testValidatedBlock) Round() basics.Round {
 	return b.Inside.Round()
 }
 
-func (b testValidatedBlock) FinishBlock(s committee.Seed, proposer basics.Address, eligible bool) agreement.ProposableBlock {
+func (b testValidatedBlock) FinishBlock(s committee.Seed, proposer basics.Address, eligible bool) bookkeeping.ProposableBlock {
 	b.Inside.BlockHeader.Seed = s
 	b.Inside.BlockHeader.Proposer = proposer
 	if !eligible {
@@ -102,7 +102,7 @@ type testBlockFactory struct {
 	Owner int
 }
 
-func (f testBlockFactory) AssembleBlock(r basics.Round, addrs []basics.Address) (agreement.UnfinishedBlock, error) {
+func (f testBlockFactory) AssembleBlock(r basics.Round, addrs []basics.Address) (bookkeeping.UnfinishedBlock, error) {
 	return testValidatedBlock{Inside: bookkeeping.Block{BlockHeader: bookkeeping.BlockHeader{Round: r}}}, nil
 }
 

--- a/agreement/common_test.go
+++ b/agreement/common_test.go
@@ -169,7 +169,7 @@ func (b testValidatedBlock) Round() basics.Round {
 	return b.Inside.Round()
 }
 
-func (b testValidatedBlock) FinishBlock(s committee.Seed, proposer basics.Address, eligible bool) ProposableBlock {
+func (b testValidatedBlock) FinishBlock(s committee.Seed, proposer basics.Address, eligible bool) bookkeeping.ProposableBlock {
 	b.Inside.BlockHeader.Seed = s
 	b.Inside.BlockHeader.Proposer = proposer
 	if !eligible {
@@ -188,7 +188,7 @@ type testBlockFactory struct {
 	Owner int
 }
 
-func (f testBlockFactory) AssembleBlock(r basics.Round, _ []basics.Address) (UnfinishedBlock, error) {
+func (f testBlockFactory) AssembleBlock(r basics.Round, _ []basics.Address) (bookkeeping.UnfinishedBlock, error) {
 	return testValidatedBlock{Inside: bookkeeping.Block{BlockHeader: bookkeeping.BlockHeader{Round: r}}}, nil
 }
 

--- a/agreement/fuzzer/ledger_test.go
+++ b/agreement/fuzzer/ledger_test.go
@@ -97,7 +97,7 @@ func (b testValidatedBlock) Round() basics.Round {
 	return b.Inside.Round()
 }
 
-func (b testValidatedBlock) FinishBlock(s committee.Seed, proposer basics.Address, eligible bool) agreement.ProposableBlock {
+func (b testValidatedBlock) FinishBlock(s committee.Seed, proposer basics.Address, eligible bool) bookkeeping.ProposableBlock {
 	b.Inside.BlockHeader.Seed = s
 	b.Inside.BlockHeader.Proposer = proposer
 	if !eligible {
@@ -116,7 +116,7 @@ type testBlockFactory struct {
 	Owner int
 }
 
-func (f testBlockFactory) AssembleBlock(r basics.Round, _ []basics.Address) (agreement.UnfinishedBlock, error) {
+func (f testBlockFactory) AssembleBlock(r basics.Round, _ []basics.Address) (bookkeeping.UnfinishedBlock, error) {
 	return testValidatedBlock{Inside: bookkeeping.Block{BlockHeader: bookkeeping.BlockHeader{Round: r}}}, nil
 }
 

--- a/agreement/proposal.go
+++ b/agreement/proposal.go
@@ -102,7 +102,7 @@ type proposal struct {
 	validatedAt time.Duration
 }
 
-func makeProposalFromProposableBlock(blk ProposableBlock, pf crypto.VrfProof, origPer period, origProp basics.Address) proposal {
+func makeProposalFromProposableBlock(blk bookkeeping.ProposableBlock, pf crypto.VrfProof, origPer period, origProp basics.Address) proposal {
 	e := blk.Block()
 	var payload unauthenticatedProposal
 	payload.Block = e
@@ -295,7 +295,7 @@ func payoutEligible(rnd basics.Round, proposer basics.Address, ledger LedgerRead
 	return eligible, balanceRecord, nil
 }
 
-func proposalForBlock(address basics.Address, vrf *crypto.VRFSecrets, blk UnfinishedBlock, period period, ledger LedgerReader) (proposal, proposalValue, error) {
+func proposalForBlock(address basics.Address, vrf *crypto.VRFSecrets, blk bookkeeping.UnfinishedBlock, period period, ledger LedgerReader) (proposal, proposalValue, error) {
 	rnd := blk.Round()
 
 	cparams, err := ledger.ConsensusParams(ParamsRound(rnd))

--- a/data/datatest/impls.go
+++ b/data/datatest/impls.go
@@ -53,7 +53,7 @@ type entryFactoryImpl struct {
 }
 
 // AssembleBlock implements Ledger.AssembleBlock.
-func (i entryFactoryImpl) AssembleBlock(round basics.Round, _ []basics.Address) (agreement.UnfinishedBlock, error) {
+func (i entryFactoryImpl) AssembleBlock(round basics.Round, _ []basics.Address) (bookkeeping.UnfinishedBlock, error) {
 	prev, err := i.l.BlockHdr(round - 1)
 	if err != nil {
 		return nil, fmt.Errorf("could not make proposals: could not read block from ledger at round %v: %v", round, err)
@@ -65,7 +65,7 @@ func (i entryFactoryImpl) AssembleBlock(round basics.Round, _ []basics.Address) 
 }
 
 // FinishBlock implements the agreement.UnfinishedBlock interface.
-func (ve validatedBlock) FinishBlock(s committee.Seed, proposer basics.Address, eligible bool) agreement.ProposableBlock {
+func (ve validatedBlock) FinishBlock(s committee.Seed, proposer basics.Address, eligible bool) bookkeeping.ProposableBlock {
 	newblock := *ve.blk
 	newblock.BlockHeader.Seed = s
 	newblock.BlockHeader.Proposer = proposer

--- a/ledger/eval/eval_test.go
+++ b/ledger/eval/eval_test.go
@@ -990,7 +990,7 @@ func (ledger *evalTestLedger) endBlock(t testing.TB, eval *BlockEvaluator) *ledg
 	// fake agreement's setting of header fields so later validates work.
 	seed := committee.Seed{}
 	crypto.RandBytes(seed[:])
-	validatedBlock := ledgercore.MakeValidatedBlock(unfinishedBlock.UnfinishedBlock().WithProposer(seed, testPoolAddr, true), unfinishedBlock.UnfinishedDeltas())
+	validatedBlock := ledgercore.MakeValidatedBlock(unfinishedBlock.UnfinishedBlock().WithProposer(seed, testPoolAddr, true).Block(), unfinishedBlock.UnfinishedDeltas())
 	err = ledger.AddValidatedBlock(validatedBlock, agreement.Certificate{})
 	require.NoError(t, err)
 	return &validatedBlock
@@ -1212,7 +1212,7 @@ func TestEvalFunctionForExpiredAccounts(t *testing.T) {
 	require.NoError(t, err)
 
 	// fake agreement's setting of header fields so later validates work
-	validatedBlock := ledgercore.MakeValidatedBlock(unfinishedBlock.UnfinishedBlock().WithProposer(committee.Seed{}, testPoolAddr, true), unfinishedBlock.UnfinishedDeltas())
+	validatedBlock := ledgercore.MakeValidatedBlock(unfinishedBlock.UnfinishedBlock().WithProposer(committee.Seed{}, testPoolAddr, true).Block(), unfinishedBlock.UnfinishedDeltas())
 
 	expired := false
 	for _, acct := range validatedBlock.Block().ExpiredParticipationAccounts {
@@ -1454,7 +1454,7 @@ func TestAbsenteeChecks(t *testing.T) {
 	require.NoError(t, err)
 
 	// fake agreement's setting of header fields so later validates work
-	validatedBlock := ledgercore.MakeValidatedBlock(unfinishedBlock.UnfinishedBlock().WithProposer(committee.Seed{}, testPoolAddr, true), unfinishedBlock.UnfinishedDeltas())
+	validatedBlock := ledgercore.MakeValidatedBlock(unfinishedBlock.UnfinishedBlock().WithProposer(committee.Seed{}, testPoolAddr, true).Block(), unfinishedBlock.UnfinishedDeltas())
 
 	require.Zero(t, validatedBlock.Block().ExpiredParticipationAccounts)
 	require.Contains(t, validatedBlock.Block().AbsentParticipationAccounts, addrs[0], addrs[0].String())

--- a/ledger/ledgercore/validatedBlock.go
+++ b/ledger/ledgercore/validatedBlock.go
@@ -84,7 +84,7 @@ func (ub UnfinishedBlock) ContainsAddress(addr basics.Address) bool {
 }
 
 // FinishBlock completes the block and returns a proposable block.
-func (ub UnfinishedBlock) FinishBlock(s committee.Seed, proposer basics.Address, eligible bool) bookkeeping.Block {
+func (ub UnfinishedBlock) FinishBlock(s committee.Seed, proposer basics.Address, eligible bool) bookkeeping.ProposableBlock {
 	return ub.blk.WithProposer(s, proposer, eligible)
 }
 

--- a/ledger/simple_test.go
+++ b/ledger/simple_test.go
@@ -165,11 +165,11 @@ func endBlock(t testing.TB, ledger *Ledger, eval *eval.BlockEvaluator, proposer 
 	// can't call the agreement code, the eligibility of the prp is not
 	// considered.
 	if ledger.GenesisProto().Payouts.Enabled {
-		*gvb = ledgercore.MakeValidatedBlock(gvb.Block().WithProposer(committee.Seed(prp), prp, true), gvb.Delta())
+		*gvb = ledgercore.MakeValidatedBlock(gvb.Block().WithProposer(committee.Seed(prp), prp, true).Block(), gvb.Delta())
 	} else {
 		// To more closely mimic the agreement code, we don't
 		// write the proposer when !Payouts.Enabled.
-		*gvb = ledgercore.MakeValidatedBlock(gvb.Block().WithProposer(committee.Seed(prp), basics.Address{}, false), gvb.Delta())
+		*gvb = ledgercore.MakeValidatedBlock(gvb.Block().WithProposer(committee.Seed(prp), basics.Address{}, false).Block(), gvb.Delta())
 	}
 
 	vvb, err := validateWithoutSignatures(t, ledger, gvb.Block())

--- a/node/impls.go
+++ b/node/impls.go
@@ -26,6 +26,7 @@ import (
 	"github.com/algorand/go-algorand/data/basics"
 	"github.com/algorand/go-algorand/data/bookkeeping"
 	"github.com/algorand/go-algorand/ledger"
+	"github.com/algorand/go-algorand/ledger/ledgercore"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/network"
 	"github.com/algorand/go-algorand/util/execpool"
@@ -59,7 +60,7 @@ func (i blockValidatorImpl) Validate(ctx context.Context, e bookkeeping.Block) (
 		return nil, err
 	}
 
-	return validatedBlock{vb: lvb}, nil
+	return lvb, nil
 }
 
 // agreementLedger implements the agreement.Ledger interface.
@@ -86,7 +87,7 @@ func (l agreementLedger) EnsureBlock(e bookkeeping.Block, c agreement.Certificat
 
 // EnsureValidatedBlock implements agreement.LedgerWriter.EnsureValidatedBlock.
 func (l agreementLedger) EnsureValidatedBlock(ve agreement.ValidatedBlock, c agreement.Certificate) {
-	l.Ledger.EnsureValidatedBlock(ve.(validatedBlock).vb, c)
+	l.Ledger.EnsureValidatedBlock(ve.(*ledgercore.ValidatedBlock), c)
 	// let the network know that we've made some progress.
 	l.n.OnNetworkAdvance()
 }

--- a/node/node.go
+++ b/node/node.go
@@ -1289,37 +1289,8 @@ func (node *AlgorandFullNode) SetCatchpointCatchupMode(catchpointCatchupMode boo
 
 }
 
-// validatedBlock satisfies agreement.ValidatedBlock
-type validatedBlock struct {
-	vb *ledgercore.ValidatedBlock
-}
-
-// unfinishedBlock satisfies agreement.UnfinishedBlock
-type unfinishedBlock struct {
-	blk *ledgercore.UnfinishedBlock
-}
-
-// proposableBlock satisfies agreement.ProposableBlock
-type proposableBlock struct {
-	blk bookkeeping.Block
-}
-
-// Block satisfies the agreement.ValidatedBlock interface.
-func (vb validatedBlock) Block() bookkeeping.Block { return vb.vb.Block() }
-
-// Round satisfies the agreement.UnfinishedBlock interface.
-func (ub unfinishedBlock) Round() basics.Round { return ub.blk.Round() }
-
-// Block satisfies the agreement.ProposableBlock interface.
-func (ab proposableBlock) Block() bookkeeping.Block { return ab.blk }
-
-// FinishBlock satisfies the agreement.UnfinishedBlock interface.
-func (ub unfinishedBlock) FinishBlock(s committee.Seed, proposer basics.Address, eligible bool) agreement.ProposableBlock {
-	return proposableBlock{blk: ub.blk.FinishBlock(s, proposer, eligible)}
-}
-
 // AssembleBlock implements Ledger.AssembleBlock.
-func (node *AlgorandFullNode) AssembleBlock(round basics.Round, addrs []basics.Address) (agreement.UnfinishedBlock, error) {
+func (node *AlgorandFullNode) AssembleBlock(round basics.Round, addrs []basics.Address) (bookkeeping.UnfinishedBlock, error) {
 	deadline := time.Now().Add(node.config.ProposalAssemblyTime)
 	ub, err := node.transactionPool.AssembleBlock(round, deadline)
 	if err != nil {
@@ -1350,7 +1321,7 @@ func (node *AlgorandFullNode) AssembleBlock(round basics.Round, addrs []basics.A
 		}
 	}
 
-	return unfinishedBlock{blk: ub}, nil
+	return ub, nil
 }
 
 // getOfflineClosedStatus will return an int with the appropriate bit(s) set if it is offline and/or online


### PR DESCRIPTION
Trying to simplify the `*Block` interfaces my moving them into `bookkeeping`

This allows `ledgercore` and `agreement` to use them, and avoids
several shim types in `node` and `agreement`.  I believe we retain all
the compile time safety that we had (and the single runtime check in
node that confirms we have `ledgercore.ValidatedBlock`.

